### PR TITLE
Add unpkg entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "Animation Library for creating GIF-like loops",
   "main": "main.js",
+  "unpkg": "dist/glc.min.js",
   "dependencies": {},
   "devDependencies": {
     "browserify": "^12.0.1",


### PR DESCRIPTION
This adds an unpkg field to package.json, which makes it easier
for people to include gifloopcoder by referring to it at
`unpkg.com/gifloopcoder`. See [unpkg](https://unpkg.com/#/) for more
information.